### PR TITLE
fix: replace static buffer allocation on growth

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "description": "THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.",
+    "prHeader": "Update Request | Renovate Bot",
+    "extends": [
+        ":dependencyDashboard",
+        ":gitSignOff",
+        ":semanticCommitScopeDisabled",
+        "schedule:earlyMondays"
+    ],
+    "packageRules": [
+        {
+            "groupName": "dependencies",
+            "matchUpdateTypes": [
+                "major",
+                "minor",
+                "patch",
+                "pin",
+                "digest"
+            ]
+        },
+        {
+            "enabled": false,
+            "matchFileNames": [
+                "Dockerfile"
+            ]
+        },
+        {
+            "enabled": false,
+            "matchFileNames": [
+                ".github/workflows/*.yaml"
+            ]
+        }
+    ],
+    "separateMajorMinor": false
+}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-11-26T17:07:18Z by kres 232fe63.
+# Generated on 2025-01-30T12:16:36Z by kres 987bf4d.
 
 # options for analysis running
 run:
@@ -17,7 +17,6 @@ output:
       path: stdout
   print-issued-lines: true
   print-linter-name: true
-  uniq-by-line: true
   path-prefix: ""
 
 # all available settings of specific linters
@@ -134,6 +133,7 @@ linters:
     - perfsprint # complains about us using fmt.Sprintf in non-performance critical code, updating just kres took too long
     - goimports # same as gci
     - musttag # seems to be broken - goes into imported libraries and reports issues there
+    - exportloopref # WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
 
 issues:
   exclude: [ ]
@@ -143,6 +143,7 @@ issues:
   max-issues-per-linter: 10
   max-same-issues: 3
   new: false
+  uniq-by-line: true
 
 severity:
   default-severity: error

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# syntax = docker/dockerfile-upstream:1.11.1-labs
+# syntax = docker/dockerfile-upstream:1.12.1-labs
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-11-26T17:07:18Z by kres 232fe63.
+# Generated on 2025-01-30T12:16:36Z by kres 987bf4d.
 
 ARG TOOLCHAIN
 
@@ -10,12 +10,12 @@ ARG TOOLCHAIN
 FROM scratch AS generate
 
 # runs markdownlint
-FROM docker.io/oven/bun:1.1.36-alpine AS lint-markdown
+FROM docker.io/oven/bun:1.1.43-alpine AS lint-markdown
 WORKDIR /src
-RUN bun i markdownlint-cli@0.43.0 sentences-per-line@0.2.1
+RUN bun i markdownlint-cli@0.43.0 sentences-per-line@0.3.0
 COPY .markdownlint.json .
 COPY ./README.md ./README.md
-RUN bunx markdownlint --ignore "CHANGELOG.md" --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --rules node_modules/sentences-per-line/index.js .
+RUN bunx markdownlint --ignore "CHANGELOG.md" --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --rules sentences-per-line .
 
 # base toolchain image
 FROM --platform=${BUILDPLATFORM} ${TOOLCHAIN} AS toolchain

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-11-26T17:07:18Z by kres 232fe63.
+# Generated on 2025-01-30T12:16:36Z by kres 987bf4d.
 
 # common variables
 
@@ -17,15 +17,15 @@ WITH_RACE ?= false
 REGISTRY ?= ghcr.io
 USERNAME ?= siderolabs
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
-PROTOBUF_GO_VERSION ?= 1.35.2
+PROTOBUF_GO_VERSION ?= 1.36.2
 GRPC_GO_VERSION ?= 1.5.1
-GRPC_GATEWAY_VERSION ?= 2.24.0
+GRPC_GATEWAY_VERSION ?= 2.25.1
 VTPROTOBUF_VERSION ?= 0.6.0
-GOIMPORTS_VERSION ?= 0.27.0
+GOIMPORTS_VERSION ?= 0.29.0
 DEEPCOPY_VERSION ?= v0.5.6
-GOLANGCILINT_VERSION ?= v1.62.0
+GOLANGCILINT_VERSION ?= v1.63.4
 GOFUMPT_VERSION ?= v0.7.0
-GO_VERSION ?= 1.23.3
+GO_VERSION ?= 1.23.5
 GO_BUILDFLAGS ?=
 GO_LDFLAGS ?=
 CGO_ENABLED ?= 0
@@ -41,13 +41,13 @@ PLATFORM ?= linux/amd64
 PROGRESS ?= auto
 PUSH ?= false
 CI_ARGS ?=
-BUILDKIT_MULTI_PLATFORM ?= 1
+BUILDKIT_MULTI_PLATFORM ?=
 COMMON_ARGS = --file=Dockerfile
 COMMON_ARGS += --provenance=false
 COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
-COMMON_ARGS += --push=$(PUSH)
 COMMON_ARGS += --build-arg=BUILDKIT_MULTI_PLATFORM=$(BUILDKIT_MULTI_PLATFORM)
+COMMON_ARGS += --push=$(PUSH)
 COMMON_ARGS += --build-arg=ARTIFACTS="$(ARTIFACTS)"
 COMMON_ARGS += --build-arg=SHA="$(SHA)"
 COMMON_ARGS += --build-arg=TAG="$(TAG)"
@@ -145,14 +145,17 @@ clean:  ## Cleans up all artifacts.
 target-%:  ## Builds the specified target defined in the Dockerfile. The build result will only remain in the build cache.
 	@$(BUILD) --target=$* $(COMMON_ARGS) $(TARGET_ARGS) $(CI_ARGS) .
 
+registry-%:  ## Builds the specified target defined in the Dockerfile and the output is an image. The image is pushed to the registry if PUSH=true.
+	@$(MAKE) target-$* TARGET_ARGS="--tag=$(REGISTRY)/$(USERNAME)/$(IMAGE_NAME):$(IMAGE_TAG)" BUILDKIT_MULTI_PLATFORM=1
+
 local-%:  ## Builds the specified target defined in the Dockerfile using the local output type. The build result will be output to the specified local destination.
 	@$(MAKE) target-$* TARGET_ARGS="--output=type=local,dest=$(DEST) $(TARGET_ARGS)"
 	@PLATFORM=$(PLATFORM) DEST=$(DEST) bash -c '\
 	  for platform in $$(tr "," "\n" <<< "$$PLATFORM"); do \
-	    echo $$platform; \
 	    directory="$${platform//\//_}"; \
 	    if [[ -d "$$DEST/$$directory" ]]; then \
-	      mv "$$DEST/$$directory/"* $$DEST; \
+		  echo $$platform; \
+	      mv -f "$$DEST/$$directory/"* $$DEST; \
 	      rmdir "$$DEST/$$directory/"; \
 	    fi; \
 	  done'

--- a/circular_test.go
+++ b/circular_test.go
@@ -87,7 +87,11 @@ func TestWrites(t *testing.T) {
 			req.NoError(err)
 			req.Equal(5000, n)
 
-			req.Equal(8192, buf.Capacity())
+			// capacity might grow to a number specific to the way `slices.Grow` works,
+			// but it should be within reasonable bounds
+			req.GreaterOrEqual(buf.Capacity(), 8192)
+			req.LessOrEqual(buf.Capacity(), 16384)
+
 			req.EqualValues(6100, buf.Offset())
 
 			for i := range 20 {

--- a/reader.go
+++ b/reader.go
@@ -126,11 +126,11 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 		n = int(r.endOff - r.off)
 	}
 
-	n = min(min(n, len(p)), cap(r.buf.data))
+	n = min(min(n, len(p)), r.buf.capacity())
 
 	i := int(r.off % int64(r.buf.opt.MaxCapacity))
 
-	if l := cap(r.buf.data) - i; l < n {
+	if l := r.buf.capacity() - i; l < n {
 		copy(p, r.buf.data[i:])
 		copy(p[l:], r.buf.data[:n-l])
 	} else {


### PR DESCRIPTION
Use `slices.Grow` and follow whatever algorithm it uses internally to pick the next size of the buffer.

So the growth might not be exactly what we asked for, but it should be optimal from Go runtime point of view.